### PR TITLE
fix null object instead of list

### DIFF
--- a/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -32,7 +32,7 @@ class DependencyManager {
     private SampleTrackingPortletController portletController
     private PortletView portletView
 
-    private final List<Service> trackingServices
+    private final List<Service> trackingServices = new ArrayList<>()
 
     private ServiceUser serviceUser
 


### PR DESCRIPTION
service list was not initialized. Adding services that were found to a null object failed.