### PR TITLE
Prevent QBiC status selection

### DIFF
--- a/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
@@ -52,7 +52,10 @@ class ControlElements extends VerticalLayout {
         // Add menu allowing status selection for new sample
         statusSelectMenu = new NativeSelect<Status>("New Sample Status")
         statusSelectMenu.setEmptySelectionAllowed(false)
-        statusSelectMenu.setItems(Status.values())
+        ArrayList<Status> filteredStatusList = new ArrayList<Status>([Status.DATA_AT_QBIC, Status.METADATA_REGISTERED])
+        ArrayList<Status> selectableStatusList = getSelectableStatusList(filteredStatusList)
+        System.out.println(selectableStatusList)
+        statusSelectMenu.setItems(selectableStatusList)
 
         /* For Test purposes
         //TODO: remove in release
@@ -77,6 +80,14 @@ class ControlElements extends VerticalLayout {
         row2.addComponentsAndExpand(locationSelectMenu, statusSelectMenu)
         row3.addComponentsAndExpand(updateSampleButton, clearButton)
         this.addComponents(row1, row2, row3)
+    }
+
+    private ArrayList<Status> getSelectableStatusList(ArrayList<Status> filterList) {
+        ArrayList<Status> selectableStatusList = Status.values()
+        for (item in filterList) {
+            selectableStatusList.removeIf({ n -> (n.toString().toUpperCase() == item.toString().toUpperCase()) })
+        }
+        return selectableStatusList
     }
 
     private void registerListeners() {

--- a/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
@@ -10,6 +10,7 @@ import life.qbic.portal.sampletracking.web.ViewModel
 @Log4j2
 class ControlElements extends VerticalLayout {
 
+    final static List<Status> FORBIDDEN_STATUS_OPTIONS = new ArrayList([Status.DATA_AT_QBIC, Status.METADATA_REGISTERED])
 
     final private PortletController controller
     final private ViewModel viewModel
@@ -48,10 +49,12 @@ class ControlElements extends VerticalLayout {
         // Add menu allowing status selection for new sample
         statusSelectMenu = new NativeSelect<Status>("New Sample Status")
         statusSelectMenu.setEmptySelectionAllowed(false)
-List<Status> selectableStatusOptions = Status.values().findall { status ->
-  !(status in FORBIDDEN_STATUS_OPTIONS)
-}
-statusSelectMenu.setItems(selectableStatusOptions)
+
+        List<Status> selectableStatusOptions = Status.values().findAll { status ->
+            !(status in FORBIDDEN_STATUS_OPTIONS)
+        }
+
+        statusSelectMenu.setItems(selectableStatusOptions)
 
         // Add button enabling sample update to SampleList
         updateSampleButton = new Button("Update Samples")

--- a/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
@@ -32,7 +32,7 @@ class ControlElements extends VerticalLayout {
 
     private def initLayout() {
 
-        // Add textField showing email address of portal user
+        // Add text showing email address of portal user
         userEmailField = new Label()
         userEmailField.setValue("You are not logged in.")
 

--- a/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
@@ -48,9 +48,10 @@ class ControlElements extends VerticalLayout {
         // Add menu allowing status selection for new sample
         statusSelectMenu = new NativeSelect<Status>("New Sample Status")
         statusSelectMenu.setEmptySelectionAllowed(false)
-        ArrayList<Status> filteredStatusList = new ArrayList<Status>([Status.DATA_AT_QBIC, Status.METADATA_REGISTERED])
-        ArrayList<Status> selectableStatusList = getSelectableStatusList(filteredStatusList)
-        statusSelectMenu.setItems(selectableStatusList)
+List<Status> selectableStatusOptions = Status.values().findall { status ->
+  !(status in FORBIDDEN_STATUS_OPTIONS)
+}
+statusSelectMenu.setItems(selectableStatusOptions)
 
         // Add button enabling sample update to SampleList
         updateSampleButton = new Button("Update Samples")

--- a/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
@@ -32,17 +32,13 @@ class ControlElements extends VerticalLayout {
 
     private def initLayout() {
 
-        // Add textfield showing email address of portal user
+        // Add textField showing email address of portal user
         userEmailField = new Label()
         userEmailField.setValue("You are not logged in.")
 
         // Add menu allowing location picking for new sample
         locationSelectMenu = new NativeSelect<>("New Sample Location")
         locationSelectMenu.setItems(viewModel.availableLocations)
-        /* For Test purposes
-        //TODO remove in release
-        locationSelectMenu.setItems("QBiC", "Home Office", "Laboratory", "Shipping")
-        */
 
         // Add menu allowing date picking for new sample
         dateChooser = new DateField("New Arrival Date")
@@ -54,13 +50,7 @@ class ControlElements extends VerticalLayout {
         statusSelectMenu.setEmptySelectionAllowed(false)
         ArrayList<Status> filteredStatusList = new ArrayList<Status>([Status.DATA_AT_QBIC, Status.METADATA_REGISTERED])
         ArrayList<Status> selectableStatusList = getSelectableStatusList(filteredStatusList)
-        System.out.println(selectableStatusList)
         statusSelectMenu.setItems(selectableStatusList)
-
-        /* For Test purposes
-        //TODO: remove in release
-        sampleSelectMenu.setItems("Waiting", "Processing", "Processed")
-        */
 
         // Add button enabling sample update to SampleList
         updateSampleButton = new Button("Update Samples")
@@ -82,6 +72,7 @@ class ControlElements extends VerticalLayout {
         this.addComponents(row1, row2, row3)
     }
 
+    // Method which filters unwanted Status elements from Sample Status enumeration and returns filtered Status list
     private ArrayList<Status> getSelectableStatusList(ArrayList<Status> filterList) {
         ArrayList<Status> selectableStatusList = Status.values()
         for (item in filterList) {
@@ -93,13 +84,6 @@ class ControlElements extends VerticalLayout {
     private void registerListeners() {
 
         // Add listener to update button to upload Sample changes selected in view
-
-        //ToDo Determine how Samples from Samplelist can be connected to user selected location, date and Status
-     //   def selectedSampleIds = viewModel.requestSampleList()
-
-        //ToDo Date and responsible Persons are stored in Location, but arrivalDate gets selected here, how is this resolved?
-      //  this.updateSampleButton.addClickListener({ event -> controller.updateSamples(selectedSampleIds, locationSelectMenu.getValue(), statusSelectMenu.getValue()) })
-        //Add listener to clear button to remove add samples to SampleList
         this.clearButton.addClickListener({ event -> this.viewModel.samples.clear() })
 
     }

--- a/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
@@ -73,15 +73,6 @@ statusSelectMenu.setItems(selectableStatusOptions)
         this.addComponents(row1, row2, row3)
     }
 
-    // Method which filters unwanted Status elements from Sample Status enumeration and returns filtered Status list
-    private ArrayList<Status> getSelectableStatusList(ArrayList<Status> filterList) {
-        ArrayList<Status> selectableStatusList = Status.values()
-        for (item in filterList) {
-            selectableStatusList.removeIf({ n -> (n.toString().toUpperCase() == item.toString().toUpperCase()) })
-        }
-        return selectableStatusList
-    }
-
     private void registerListeners() {
 
         // Add listener to update button to upload Sample changes selected in view


### PR DESCRIPTION
I don't think that filtering the Sample Status in a View class is according to the clean architecture principles, but i'm also not convinced that defining additional classes is necessary for such a small fix. 