### PR TITLE
Add time zone name to date selection

### DIFF
--- a/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/web/views/ControlElements.groovy
@@ -55,7 +55,7 @@ class ControlElements extends VerticalLayout {
         locationSelectMenu.setItemCaptionGenerator({ it -> it?.name ?: "unknown" })
 
         // Add menu allowing date picking for new sample
-        dateChooser = new DateTimeField("New Arrival Date")
+        dateChooser = new DateTimeField("New Arrival Date (${TimeZone.getDefault().getID()})")
         dateChooser.setTextFieldEnabled(true)
         dateChooser.setDateFormat(DATE_TIME_PATTERN)
         dateChooser.setResolution(DateTimeResolution.MINUTE)


### PR DESCRIPTION
This commit adds the time zone id to the label of the date chooser. This is the only way any confusion from users from different time zones might be avoided.
Vaadin 8 does not offer an option for localization an thus provides no possibility to retrieve the client time zone.

A more complex approach could include the parsing and localization of the client IP address but this is not considered necessary at the moment.