### PR TITLE
Upgrade to groovy 3.0.7 and data-model-lib 1.13.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>life.qbic</groupId>
+			<artifactId>data-model-lib</artifactId>
+			<version>1.13.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>life.qbic</groupId>
 			<artifactId>portal-utils-lib</artifactId>
 			<version>2.2.1</version>
 		</dependency>
@@ -68,11 +73,30 @@
 			<artifactId>core-utils-lib</artifactId>
 			<version>1.7.0</version>
 		</dependency>
-        <dependency>
-            <groupId>org.spockframework</groupId>
-            <artifactId>spock-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+				<groupId>org.spockframework</groupId>
+				<artifactId>spock-core</artifactId>
+				<version>2.0-M4-groovy-3.0</version>
+				<scope>test</scope>
+		</dependency>
+
+		<!-- use groovy 3 -->
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-all</artifactId>
+			<version>3.0.7</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-sql</artifactId>
+			<version>3.0.7</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-json</artifactId>
+			<version>3.0.7</version>
+		</dependency>
 
 		<!-- openBIS client -->
 		<dependency>
@@ -92,12 +116,6 @@
 		</dependency>
 
 		<!-- for access to endpoints -->
-		<dependency>
-			<groupId>life.qbic</groupId>
-			<artifactId>data-model-lib</artifactId>
-			<version>1.12.0</version>
-		</dependency>
-
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>

--- a/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -62,7 +62,7 @@ class DependencyManager {
         // set up openBIS connection and data management system object
         def userID = "not logged in"
         try {
-            userID = PortalUtils.getScreenName() ?: configManager.getDataSourceUser()
+            userID = PortalUtils.getScreenName()
         } catch (NullPointerException e) {
             log.error("User not logged into Liferay. They won't be able to see samples.", e)
         }


### PR DESCRIPTION
This commit upgrades groovy from `2.5.7` to `3.0.7`
This upgrade is necessary because `data-model-lib:1.13.0-SNAPSHOT` uses Groovy `3.0.7`