### PR TITLE
Decrease the java version from 11 to 8

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Install git
         run: sudo apt-get install git
 
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }}
 

--- a/.github/workflows/nexus-publish-release.yml
+++ b/.github/workflows/nexus-publish-release.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.11
+    - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.11
+        java-version: 1.8
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }}
 

--- a/.github/workflows/nexus-publish.yml
+++ b/.github/workflows/nexus-publish.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }}
       

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
 
       - name: Load local Maven repository cache
         uses: actions/cache@v2


### PR DESCRIPTION
This PR decreases the java version used by GitHub actions to build and publish the releases.
This change is necessary due to a bug with tomcat and portlets build with Java 8 not being deployable.

```
Unable to process Jar entry [module-info.class] from Jar [jar:file:/.../WEB-INF/lib/apiguardian-api-1.1.0.jar!/] for annotations
org.apache.tomcat.util.bcel.classfile.ClassFormatException: Invalid byte tag in constant pool: 19
```