### PR TITLE
Bump data-model-lib:2.3.0 to 2.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Dependencies**
 
-* Bump ``data-model-lib:2.0.0`` -> ``2.3.0``
+* Bump ``data-model-lib:2.0.0`` -> ``2.4.0``
 
 **Deprecated**
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>data-model-lib</artifactId>
-			<version>2.3.0</version>
+			<version>2.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>life.qbic</groupId>


### PR DESCRIPTION
Bump data-model-lib from 2.3.0. to 2.4.0

- [x] `CHANGELOG.rst` is updated